### PR TITLE
Use fs-extra to remove the existing link/folder

### DIFF
--- a/crna-make-symlinks-for-yarn-workspaces/index.js
+++ b/crna-make-symlinks-for-yarn-workspaces/index.js
@@ -1,5 +1,5 @@
 const findRoot = require('find-root');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 
 const link = (name, fromBase, toBase) => {
@@ -7,7 +7,7 @@ const link = (name, fromBase, toBase) => {
   const to = path.join(toBase, 'node_modules', name);
 
   if (fs.existsSync(to)) {
-    fs.unlinkSync(to);
+    fs.removeSync(to);
   }
 
   fs.symlinkSync(from, to, 'dir');

--- a/crna-make-symlinks-for-yarn-workspaces/package.json
+++ b/crna-make-symlinks-for-yarn-workspaces/package.json
@@ -7,6 +7,7 @@
   "author": "Darío Javier Cravoro <dario@uxtemple.com>",
   "license": "MIT",
   "dependencies": {
-    "find-root": "^1.1.0"
+    "find-root": "^1.1.0",
+    "fs-extra": "^5.0.0"
   }
 }

--- a/crna-make-symlinks-for-yarn-workspaces/yarn.lock
+++ b/crna-make-symlinks-for-yarn-workspaces/yarn.lock
@@ -5,3 +5,25 @@
 find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"


### PR DESCRIPTION
`unlinkSync` only works with links, but I got to a point where I had the module folder there. Since `fs.rmdir` only works with an empty folder, `fs-extra` seems to be the right tool for the job. 
I hope this helps! 🎉
Any comment is welcome 😁