### PR TITLE
Fix windows paths

### DIFF
--- a/react-app-rewire-yarn-workspaces/index.js
+++ b/react-app-rewire-yarn-workspaces/index.js
@@ -1,4 +1,5 @@
 const getWorkspaces = require('get-yarn-workspaces')
+const path = require('path')
 
 module.exports = function rewireYarnWorkspaces(config, env, from) {
   const babel = config.module.rules
@@ -9,7 +10,7 @@ module.exports = function rewireYarnWorkspaces(config, env, from) {
     babel.include = [babel.include]
   }
 
-  babel.include = babel.include.concat(getWorkspaces(from))
+  babel.include = babel.include.concat(getWorkspaces(from).map((directory) => path.resolve(directory)))
 
   return config
 }


### PR DESCRIPTION
The paths returned from `getWorkspaces` are not platform agnostic, and break when running on windows builds. path.join will return correct platform agnostic paths, but these get corrupted by glob.sync.
`'D:\\Users\\nickm\\Documents\\Code\\my-app\\core'`

becomes

`'D:/Users/nickm/Documents/Code/my-app/core'`

Happy to move this fix across into the 'get-yarn-workspaces' package if it is preferred.

Fixes #13 